### PR TITLE
Enable install with PHP 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,40 @@
+name: tests
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [7.3, 7.4, 8.0]
+        dependency-version: [prefer-lowest, prefer-stable]
+
+    name: PHP ${{ matrix.php }} ${{ matrix.dependency-version }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        tools: composer:v2
+        coverage: none
+
+    - name: Setup Problem Matchers
+      run: |
+        echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+
+    - name: Install PHP 7 dependencies
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress
+      if: "matrix.php < 8"
+
+    - name: Install PHP 8 dependencies
+      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php
+      if: "matrix.php >= 8"
+
+    - name: Run Unit Tests
+      run: vendor/bin/phpunit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,8 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        dependency-version: [prefer-lowest, prefer-stable]
 
-    name: PHP ${{ matrix.php }} ${{ matrix.dependency-version }}
+    name: PHP ${{ matrix.php }}
 
     steps:
     - name: Checkout
@@ -29,13 +28,12 @@ jobs:
         echo "::add-matcher::${{ runner.tool_cache }}/php.json"
         echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-
     - name: Install PHP 7 dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress
+      run: composer update --no-interaction --prefer-dist --no-progress
       if: "matrix.php < 8"
 
     - name: Install PHP 8 dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist --no-progress --ignore-platform-req=php
+      run: composer update --no-interaction --prefer-dist --no-progress --ignore-platform-req=php
       if: "matrix.php >= 8"
 
     - name: Run Unit Tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 name: tests
 
+on: [ 'push', 'pull_request' ]
+
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/composer.json
+++ b/composer.json
@@ -10,14 +10,14 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1 || ^8.0",
         "dg/bypass-finals": "^1.1"
     },
     "require-dev": {
         "localheinz/phpstan-rules": "^0.10.0",
         "phpstan/phpstan": "^0.11.8",
         "phpstan/phpstan-strict-rules": "^0.11.1",
-        "phpunit/phpunit": "^7.0|^8.0",
+        "phpunit/phpunit": "^7.0|^8.0|^9.3",
         "thecodingmachine/phpstan-strict-rules": "^0.11.1"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "localheinz/phpstan-rules": "^0.10.0",
         "phpstan/phpstan": "^0.11.8",
         "phpstan/phpstan-strict-rules": "^0.11.1",
-        "phpunit/phpunit": "^8.0|^9.3",
+        "phpunit/phpunit": "^7.0|^8.0|^9.3",
         "thecodingmachine/phpstan-strict-rules": "^0.11.1"
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "localheinz/phpstan-rules": "^0.10.0",
         "phpstan/phpstan": "^0.11.8",
         "phpstan/phpstan-strict-rules": "^0.11.1",
-        "phpunit/phpunit": "^7.0|^8.0|^9.3",
+        "phpunit/phpunit": "^8.0|^9.3",
         "thecodingmachine/phpstan-strict-rules": "^0.11.1"
     },
     "autoload-dev": {


### PR DESCRIPTION
This is a fix for #1. This adds php 8.0 and phpunit 9.3 (required for PHP 8) to composer.json. I also added a github action to run the tests on each PHP version.

I ran into a config issue that means the action always installs with `prefer-stable`, and that means it uses phpunit 9.3 on all PHP versions. The tests all pass, but it means that version combos enabled with `prefer-lowest` do not get tested, and I know that some would break, such as phpunit 7 on php 8.0. However, I can't see a way to exclude them that's not very messy.