### PR TITLE
Support ParaTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ composer require --dev nunomaduro/mock-final-classes
 ## 🤯 How it works?
 
 1. First, we run the file [autoload.php](https://github.com/nunomaduro/mock-final-classes/blob/master/autoload.php) using [Composer Autoload](https://github.com/nunomaduro/mock-final-classes/blob/8628de25120b6106421d7730457c45ac668ecef9/composer.json#L35).
-2. Then, if you are running the command [PHPUnit](https://github.com/nunomaduro/mock-final-classes/blob/master/src/Frameworks/PhpUnit.php), we use the library [dg/bypass-finals](https://github.com/dg/bypass-finals) to remove final keywords from source code on-the-fly: [https://github.com/nunomaduro/mock-final-classes/src/Runner.php#L31](https://github.com/nunomaduro/mock-final-classes/blob/8628de25120b6106421d7730457c45ac668ecef9/src/Runner.php#L31).
+2. Then, we determine if you are running a supported test framework
+   - [ParaTest](https://github.com/nunomaduro/mock-final-classes/blob/master/src/Frameworks/ParaTest.php)
+   - [Pest](https://github.com/nunomaduro/mock-final-classes/blob/master/src/Frameworks/Pest.php)
+   - [PHPUnit](https://github.com/nunomaduro/mock-final-classes/blob/master/src/Frameworks/PhpUnit.php)
+3. Then, we use the library [dg/bypass-finals](https://github.com/dg/bypass-finals) to remove final keywords from source code on-the-fly: [https://github.com/nunomaduro/mock-final-classes/src/Runner.php#L31](https://github.com/nunomaduro/mock-final-classes/blob/8628de25120b6106421d7730457c45ac668ecef9/src/Runner.php#L31).
 
 ## 👏🏻 Credits
 

--- a/src/Frameworks/ParaTest.php
+++ b/src/Frameworks/ParaTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NunoMaduro\MockFinalClasses\Frameworks;
+
+use NunoMaduro\MockFinalClasses\Contracts\Framework;
+
+/**
+ * @internal
+ */
+final class ParaTest implements Framework
+{
+    public function isRunning(): bool
+    {
+        return PHP_SAPI === 'cli'
+            && strpos($_SERVER['argv'][0], 'paratest') !== false;
+    }
+}

--- a/src/Runner.php
+++ b/src/Runner.php
@@ -19,6 +19,7 @@ final class Runner
     private static $frameworks = [
         Frameworks\PhpUnit::class,
         Frameworks\Pest::class,
+        Frameworks\ParaTest::class,
     ];
 
     /**


### PR DESCRIPTION
ParaTest: https://github.com/paratestphp/paratest

While ParaTest would usually spawn new processes for PHPUnit, when analyzing the tests to run it will call data providers directly. Specifically in combination with OPcache on Windows sharing loaded classes across processes, final classes loaded in a data provider would then not be mockable.